### PR TITLE
Auto scale fix

### DIFF
--- a/src/JUDI4Cloud.jl
+++ b/src/JUDI4Cloud.jl
@@ -68,8 +68,12 @@ function init_culsterless(nworkers=2; credentials=nothing, vm_size="Standard_E8s
         @eval(AzureClusterlessHPC, global __clients__ = create_clients(__credentials__, batch=true, blob=true))
     end
     # Create pool with idle autoscale. This will be much more efficient with a defined image rather than docker.
-    create_pool(;enable_auto_scale=auto_scale, auto_scale_formula=auto_scale_formula(nworkers), 
+    if auto_scale
+        create_pool(;enable_auto_scale=auto_scale, auto_scale_formula=auto_scale_formula(nworkers), 
                 auto_scale_evaluation_interval_minutes=5)
+    else
+        create_pool(;enable_auto_scale=auto_scale)
+    end
 
     # Export JUDI on azure
     eval(macroexpand(JUDI4Cloud, quote @batchdef using Distributed, JUDI end))

--- a/src/JUDI4Cloud.jl
+++ b/src/JUDI4Cloud.jl
@@ -5,7 +5,7 @@ import Base.vcat, Base.+
 using AzureClusterlessHPC, Reexport
 @reexport using JUDI
 
-export init_culsterless
+export init_culsterless, finalize_culsterless
 
 _judi_defaults = Dict("_POOL_ID"                => "JudiPool",
                     "_POOL_VM_SIZE"           => "Standard_E8s_v3",

--- a/src/JUDI4Cloud.jl
+++ b/src/JUDI4Cloud.jl
@@ -5,7 +5,7 @@ import Base.vcat, Base.+
 using AzureClusterlessHPC, Reexport
 @reexport using JUDI
 
-export init_culsterless, finalize_culsterless
+export init_culsterless
 
 _judi_defaults = Dict("_POOL_ID"                => "JudiPool",
                     "_POOL_VM_SIZE"           => "Standard_E8s_v3",


### PR DESCRIPTION
`init_culsterless(2; auto_scale=false)` produces an error in AzureClusterlessHPC on this line https://github.com/slimgroup/JUDI4Cloud.jl/blob/e40ee7c644302a03ce5cc99046d42ba6df6960c5/src/JUDI4Cloud.jl#L71

`Failed to start pool 1 of 1 in eastus. Verify that you have correct credentials, a batch account with AAD authentication and that pool parameters are correct.`

Removing the `auto_scale_formula` etc when it's not needed will solve the problem